### PR TITLE
Update QT version requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pytube
 requests==2.32.3
 scrapetube
 yt-dlp
-PyQt6==6.7.1
+PyQt6
 PyQt6-WebEngine


### PR DESCRIPTION
My system has a much newer version of QT, so installing PyQt6==6.7.1 leads to error 

```
$ python3 main.py
Traceback (most recent call last):
  File "/home/.../main.py", line 18, in <module>
    from classes.mainwindow import MainWindow
  File "/home/.../classes/mainwindow.py", line 30, in <module>
    from classes.dialogs import CustomDialog
  File "/home/.../classes/dialogs.py", line 14, in <module>
    from PyQt6.QtWebEngineWidgets import QWebEngineView
ImportError: /home/.../.venv/lib/python3.13/site-packages/PyQt6/Qt6/lib/libQt6Core.so.6: version `Qt_6.8' not found (required by /home/.../.venv/lib/python3.13/site-packages/PyQt6/QtWebEngineWidgets.abi3.so)
```
**The fix is to remove the hard-coded version from the requirements**