### PR TITLE
feat(ui): enable sorting on video list table

### DIFF
--- a/src/yt_channel_downloader/classes/mainwindow.py
+++ b/src/yt_channel_downloader/classes/mainwindow.py
@@ -724,6 +724,7 @@ class MainWindow(QMainWindow):
         self.model.setHorizontalHeaderLabels(
             ['Download?', 'Title', 'Duration', 'Link', 'Speed', 'Progress'])
         self.ui.treeView.setModel(self.model)
+        self.ui.treeView.setSortingEnabled(True)
         self.progress_widgets.clear()
         self.estimated_download_sizes.clear()
         self.speed_history.clear()

--- a/src/yt_channel_downloader/classes/videoitem.py
+++ b/src/yt_channel_downloader/classes/videoitem.py
@@ -10,6 +10,26 @@ from PyQt6 import QtGui, QtCore
 THUMBNAIL_URL_ROLE = QtCore.Qt.ItemDataRole.UserRole + 10
 
 
+class SortableStandardItem(QtGui.QStandardItem):
+    """
+    Subclass of QStandardItem that sorts by UserRole data (numeric)
+    instead of DisplayRole (string) when available.
+    """
+    def __lt__(self, other):
+        role = QtCore.Qt.ItemDataRole.UserRole
+        my_data = self.data(role)
+        other_data = other.data(role)
+
+        # If both have user data, compare that
+        if my_data is not None and other_data is not None:
+            try:
+                return float(my_data) < float(other_data)
+            except (ValueError, TypeError):
+                pass  # Fallback to default behavior
+
+        return super().__lt__(other)
+
+
 class VideoItem:
     """
     Represents a video item with relevant data and methods to interact with
@@ -61,7 +81,7 @@ class VideoItem:
         item_link = QtGui.QStandardItem(self.link)
         duration_value = self._coerce_duration_value(self.duration_seconds)
         duration_display = self._format_duration(duration_value)
-        item_duration = QtGui.QStandardItem(duration_display)
+        item_duration = SortableStandardItem(duration_display)
         if duration_value is not None:
             item_duration.setData(duration_value, QtCore.Qt.ItemDataRole.UserRole)
         item_speed = QtGui.QStandardItem("—")


### PR DESCRIPTION
I just wanted a quick way to "sort by duration", so I vibed this together real quick
It might be useful upstream, otherwise just ignore this! :smile: 

<img width="624" height="371" alt="image" src="https://github.com/user-attachments/assets/134cb490-6d62-45fa-93f7-abced68e992e" />
